### PR TITLE
[#7] Updated runWithTimeout to use callName

### DIFF
--- a/src/main/scala/com/gilt/gfc/concurrent/FutureBuilder.scala
+++ b/src/main/scala/com/gilt/gfc/concurrent/FutureBuilder.scala
@@ -85,7 +85,7 @@ case class FutureBuilder[A,R] private (
 
     this.copy[A,R](addSingleCallTimeout = { f =>
       implicit val executor: ExecutionContext = ExecutionContext.Implicits.global
-      f.withTimeout(after, Some(s"Timed out while: $callName"))
+      f.withTimeout(after, Some(s"Timed out in: $callName ($additionalMessage)"))
     }).run(call)
   }
 


### PR DESCRIPTION
There was no need to introduce another errorMessage parameter since the FutureBuilder is already constructed with a callName, which provides context.